### PR TITLE
docs: improved links between guideline markdowns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ If you find a bug or have a suggestion, please open an issue following these gui
 - Describe the problem clearly.
 - Provide steps to reproduce it.
 - Suggest possible solutions if applicable.
+- For more detailed information checkout [Bug Report Guideline](https://github.com/FurkanHuman/Student_Exam_Generator_And_Analyzer/blob/Main/.github/ISSUE_TEMPLATE/bug_report.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,16 @@ Whether you’re an individual teacher, a school, or an institution, S.E.S. can 
 
 ## 🔄 Contribution Guidelines
 
-* 💬 Use [Semantic Commit Messages](https://github.com/FurkanHuman/Student_Exam_Generator_And_Analyzer/blob/Main/Docs/Semantic%20Commit%20Messages.md) to keep the git history clean and meaningful.
+* If you are interested in Contributing to this Project checkout the [Contributing Guidelines](https://github.com/FurkanHuman/Student_Exam_Generator_And_Analyzer/blob/Main/CONTRIBUTING.md)
+
+---
+
+# 📝 Feature Requests
+
+If you’d like to see a new feature added, please open a feature request using our  
+[Feature Request Template](https://github.com/FurkanHuman/Student_Exam_Generator_And_Analyzer/blob/Main/.github/ISSUE_TEMPLATE/feature_request.md).
+
+We appreciate your feedback and contributions!
 
 ---
 


### PR DESCRIPTION
I have improved the links between the project’s guideline markdown files to provide better clarity and navigation.